### PR TITLE
Added support for RSpec 2.6

### DIFF
--- a/lib/rspec/isolation/core_ext.rb
+++ b/lib/rspec/isolation/core_ext.rb
@@ -26,6 +26,8 @@ RSpec::Core::Example.class_eval do
       write.close
       result = Marshal.load(read.read.unpack("m").first)
       Process.wait2(pid)
+
+      raise result if result.class < Exception
       return result
     else
       yield
@@ -33,39 +35,80 @@ RSpec::Core::Example.class_eval do
   end
   
   # Redefine the run method
-  def run(example_group_instance, reporter)
-    return if RSpec.wants_to_quit
-    @example_group_instance = example_group_instance
-    @example_group_instance.example = self
-
-    start(reporter)
-
-    begin
-      unless pending
-        with_pending_capture do
+  if defined?(RSpec::Core::Version::STRING) && RSpec::Core::Version::STRING >= "2.6"
+    def run(example_group_instance, reporter)
+      @example_group_instance = example_group_instance
+      @example_group_instance.example = self
+    
+      start(reporter)
+    
+      begin
+        unless pending
           with_around_hooks do
-            begin
-              run_before_each
-              @in_block = true
-              result = isolated_or_normal { @example_group_instance.instance_eval(&@example_block) }
-              raise result if result.class < Exception
-              result
-            rescue Exception => e
-              set_exception(e)
-            ensure
-              @in_block = false
-              run_after_each
+            isolated_or_normal do
+              begin
+                run_before_each
+                @example_group_instance.instance_eval(&@example_block)
+              rescue RSpec::Core::Pending::PendingDeclaredInExample => e
+                @pending_declared_in_example = e.message
+              rescue Exception => e
+                set_exception(e)
+              ensure
+                run_after_each
+              end
             end
           end
         end
+      rescue Exception => e
+        set_exception(e)
+      ensure
+        @example_group_instance.instance_variables.each do |ivar|
+          @example_group_instance.instance_variable_set(ivar, nil)
+        end
+        @example_group_instance = nil
+    
+        begin
+          assign_auto_description
+        rescue Exception => e
+          set_exception(e)
+        end
       end
-    rescue Exception => e
-      set_exception(e)
-    ensure
-      @example_group_instance.example = nil
-      assign_auto_description
+    
+      finish(reporter)
     end
-
-    finish(reporter)
+  else
+    def run(example_group_instance, reporter)
+      return if RSpec.wants_to_quit
+      @example_group_instance = example_group_instance
+      @example_group_instance.example = self
+  
+      start(reporter)
+  
+      begin
+        unless pending
+          with_pending_capture do
+            with_around_hooks do
+              begin
+                run_before_each
+                @in_block = true
+                isolated_or_normal { @example_group_instance.instance_eval(&@example_block) }
+              rescue Exception => e
+                set_exception(e)
+              ensure
+                @in_block = false
+                run_after_each
+              end
+            end
+          end
+        end
+      rescue Exception => e
+        set_exception(e)
+      ensure
+        @example_group_instance.example = nil
+        assign_auto_description
+      end
+  
+      finish(reporter)
+    end
   end
 end

--- a/spec/rspec_isolation_spec.rb
+++ b/spec/rspec_isolation_spec.rb
@@ -26,14 +26,14 @@ describe "#isolation" do
       example = group.iso_it('example') { 1.should == 2 }
 
       group.run
-      example.metadata[:execution_result][:exception_encountered].message.should == "expected: 2,\n     got: 1 (using ==)"
+      example.should have_encountered_exception(/expected: 2,?\s+ got: 1 \(using ==\)/)
     end
     it "should capture exceptions" do
       group = RSpec::Core::ExampleGroup.describe
       example = group.iso_it('example') { raise "FOO" }
 
       group.run
-      example.metadata[:execution_result][:exception_encountered].message.should == "FOO"
+      example.should have_encountered_exception("FOO")
     end
   end
   context "complicated conditions" do
@@ -46,14 +46,14 @@ describe "#isolation" do
       end
     end
     it "should raise error if run in the same process" do
-      group = RSpec::Core::ExampleGroup.describe do
+      group = RSpec::Core::ExampleGroup.describe "test" do
         $test_counter = 0
-        example {once_then_raise_error}
-        example {once_then_raise_error}
+        it "test" do once_then_raise_error end
+        it "test" do once_then_raise_error end
       end
       group.run
-      group.examples[0].metadata[:execution_result][:exception_encountered].should be_nil
-      group.examples[1].metadata[:execution_result][:exception_encountered].message.should == "In the same process"
+      group.examples[0].should_not have_encountered_exception
+      group.examples[1].should     have_encountered_exception("In the same process")
     end
     it "should not raise if ran in isolation" do
       group = RSpec::Core::ExampleGroup.describe do
@@ -63,8 +63,8 @@ describe "#isolation" do
         example {once_then_raise_error}
       end
       group.run
-      group.examples[0].metadata[:execution_result][:exception_encountered].should be_nil
-      group.examples[0].metadata[:execution_result][:exception_encountered].should be_nil
+      group.examples[0].should_not have_encountered_exception
+      group.examples[1].should_not have_encountered_exception
     end
   end
 end

--- a/spec/support/core_matchers_ext.rb
+++ b/spec/support/core_matchers_ext.rb
@@ -1,0 +1,14 @@
+module RSpec
+  module Core
+    module Matchers
+      def fail
+        raise_error(::RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      def fail_with(message)
+        raise_error(::RSpec::Expectations::ExpectationNotMetError, message)
+      end
+    end
+  end
+end
+

--- a/spec/support/isolation_spec_matchers.rb
+++ b/spec/support/isolation_spec_matchers.rb
@@ -1,0 +1,80 @@
+# Used to test whether an exception was encountered and stored in RSpec metadata.
+#
+# Completely different from `x.should raise_error(err)`.
+#
+# Also accepts regular expressions.
+#
+# Examples:
+#
+#   # setup: run and then capture the example(s)
+#   group.run
+#   example = group.examples[0]
+#
+#   example.should_not have_encountered_exception
+#   #=> "expected not to encounter an exception, but did"
+#
+#   example.should have_encountered_exception
+#   #=> "expected to encounter an exception, but did not"
+#
+#   example.should_not have_encountered_exception("In same process")
+#   #=> 'expected not to encounter exception "In same process", but did'
+#
+#   example.should have_encountered_exception("In same process")
+#   #=> 'expected to encounter exception "In same process", but did not'
+#   #=> 'expected to encounter exception "In same process", but encountered exception "expected: 2, got: 1"'
+#
+#   example.should have_encountered_exception(/process/)
+#   #=> 'expected to encounter exception /process/, but encountered exception "expected: 2, got: 1"'
+#
+module RSpecIsolationSpecMatchers
+  class EncounteredExceptionMatcher
+    def initialize(message = nil)
+      @message = message
+    end
+    
+    def matches?(result)
+      if RSPEC_VERSION < "2.6"
+        exception = result.metadata[:execution_result]
+        exception &&= exception[:exception_encountered] && exception[:exception_encountered].message
+      else
+        exception = result.execution_result[:exception]
+        exception &&= exception.message.to_s
+      end
+      
+      @exception = exception
+      
+      if @message.kind_of?(Regexp)
+        exception && exception =~ @message
+      else
+        exception && exception == @message
+      end
+    end
+    
+    def basic_message
+      if @message
+        "expected to encounter exception #{@message.inspect}, but did not"
+      else
+        "expected to encounter an exception, but did not"
+      end
+    end
+    
+    def failure_message
+      message = basic_message
+      if @exception
+        message['did not'] = "encountered exception #{@exception.inspect}"
+      end
+      message
+    end
+    
+    def negative_failure_message
+      result = basic_message
+      result['to'] = 'not to'
+      result['did not'] = 'did' if result['did not']
+      result
+    end
+  end
+  
+  def have_encountered_exception(message = nil)
+    EncounteredExceptionMatcher.new(message)
+  end
+end

--- a/spec/support/null_object.rb
+++ b/spec/support/null_object.rb
@@ -1,0 +1,5 @@
+class NullObject
+  def method_missing(method, *args, &block)
+    # ignore
+  end
+end


### PR DESCRIPTION
This commit also moves testing of examples' exceptions into a matcher, RSpecIsolationSpecMatchers::EncounteredExceptionMatcher, which handles the version-specific exception test. This helps keep the specs somewhat clutter-free.

Tested for backward compatibility with RSpec 2.1.0.
